### PR TITLE
feat: add support for js config, change default cfg name

### DIFF
--- a/src/browser/FileTree.js
+++ b/src/browser/FileTree.js
@@ -11,7 +11,6 @@ import {
   createFolder,
   removeFile,
 } from "../node/file-tree-utils.js";
-import { configPath } from "../node/index.js";
 
 class FileTree extends LitElement {
   static get properties() {
@@ -418,7 +417,7 @@ class FileTree extends LitElement {
   }
 
   play() {
-    runStyleDictionary(configPath);
+    runStyleDictionary();
   }
 
   uncheckFolders() {

--- a/src/browser/FileTree.js
+++ b/src/browser/FileTree.js
@@ -542,12 +542,16 @@ class FileTree extends LitElement {
     );
   }
 
-  // TODO: clean this up, bit messy..
   async switchToFile(indexOrName) {
     await this.updateComplete;
     if (this.unsavedFileBtn) {
       saveCurrentFile();
     }
+    const filename = this.switchToFileInTree(indexOrName);
+    switchToFile(filename);
+  }
+
+  switchToFileInTree(indexOrName) {
     if (this.checkedFileBtn) {
       this.checkedFileBtn.removeAttribute("checked");
       this.uncheckFolders();
@@ -561,7 +565,8 @@ class FileTree extends LitElement {
     } else if (typeof indexOrName === "string") {
       filename = indexOrName;
       btn = this.fileButtons.find(
-        (btn) => btn.getAttribute("full-path") === indexOrName
+        (btn) =>
+          btn.getAttribute("full-path") === indexOrName.replace(/^\//, "")
       );
     }
     if (btn) {
@@ -571,8 +576,7 @@ class FileTree extends LitElement {
         parentFolder.setAttribute("checked", "");
       }
     }
-
-    switchToFile(filename);
+    return filename;
   }
 }
 customElements.define("file-tree", FileTree);

--- a/src/index.html
+++ b/src/index.html
@@ -147,6 +147,9 @@
         share!
       </p>
     </div>
+    <button id="jsSwitchBtn" class="js-switch-btn">
+      Switch to JS config instead of JSON
+    </button>
     <div class="playground-container">
       <file-tree></file-tree>
       <div style="height: 100%" id="monaco-container"></div>

--- a/src/node/file-tree-utils.js
+++ b/src/node/file-tree-utils.js
@@ -2,7 +2,7 @@ import fs from "fs";
 import util from "util";
 import path from "path";
 import glob from "glob";
-import { configPath, changeLang } from "./index.js";
+import { configPaths, changeLang } from "./index.js";
 import {
   styleDictionaryInstance,
   rerunStyleDictionaryIfSourceChanged,
@@ -66,7 +66,8 @@ export async function createInputFiles() {
     // Create SD config
     await new Promise((resolve) => {
       fs.writeFile(
-        configPath,
+        // take the config.json by default
+        configPaths[2],
         JSON.stringify(
           {
             source: ["tokens/**/*.json"],

--- a/src/node/file-tree-utils.js
+++ b/src/node/file-tree-utils.js
@@ -41,13 +41,9 @@ export async function createInputFiles() {
           if (dir !== "/") {
             await mkdirRecursive(dir);
           }
-          fs.writeFile(
-            file,
-            JSON.stringify(JSON.parse(content), null, 2),
-            (err) => {
-              resolve();
-            }
-          );
+          fs.writeFile(file, content, (err) => {
+            resolve();
+          });
         });
       })
     );

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -32,7 +32,7 @@ export async function encodeContents(files) {
     files.map(async (file) => {
       await new Promise((resolve) => {
         fs.readFile(file, "utf-8", (err, data) => {
-          contents[file] = JSON.stringify(JSON.parse(data));
+          contents[file] = data;
           resolve();
         });
       });

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -5,11 +5,19 @@ import {
   setupFileChangeHandlers,
   repopulateFileTree,
 } from "./file-tree-utils.js";
-import runStyleDictionary from "./run-style-dictionary.js";
+import runStyleDictionary, {
+  findUsedConfigPath,
+} from "./run-style-dictionary.js";
 import { ensureMonacoIsLoaded, editor, monaco } from "../browser/monaco.js";
 import "../browser/index.js";
 
-export const configPath = path.resolve("sd.config.json");
+// supported config paths, prioritized in this order
+export const configPaths = [
+  "config.js",
+  "sd.config.js",
+  "config.json",
+  "sd.config.json",
+].map((p) => path.resolve(p));
 
 export async function changeLang(lang) {
   await ensureMonacoIsLoaded();
@@ -17,6 +25,8 @@ export async function changeLang(lang) {
 }
 
 export async function encodeContents(files) {
+  const configPath = findUsedConfigPath();
+  files = [configPath, ...files];
   const contents = {};
   await Promise.all(
     files.map(async (file) => {

--- a/src/style.css
+++ b/src/style.css
@@ -76,6 +76,21 @@ h1 {
   margin: 0.5rem 0;
 }
 
+.js-switch-btn {
+  background-color: #82dbd2;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+  border-radius: 4px;
+  margin: 0 auto 1rem auto;
+  display: block;
+}
+
+.js-switch-btn:hover {
+  cursor: pointer;
+  background-color: #5bb8ae;
+}
+
 .playground-container {
   height: 75vh;
   display: flex;


### PR DESCRIPTION
Doesn't work yet, when passing a JS config path, it will read the file and parse as JSON 🙈 

browser-style-dictionary only accepts JSON config path or JS object, so instead what we can do:
- [x] run rollup on runtime on the JS config string, creating a UMD bundle for it (should cover the case where people may import something in the config)
- [x] make this UMD bundle into a Blob
- [x] dynamic import Blob
- [x] pass the JS object to StyleDictionary.extend()
- [x] button to easily switch to JS config

Edit: only allowing ESM format, rollup CJS plugin in browser is not trivial and ESM makes sense for browser env, so let's just enforce that..

Would maybe be nicer to format the JS to remove the redundant double quotes e.g. with prettier, let's do it in a later PR

![gif of change](https://i.imgur.com/1nekU2v.gif)
