### PR TITLE
allow JS tokens and bundle to support relative imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@lion/core": "^0.18.4",
         "@lion/overlays": "^0.26.1",
-        "browser-style-dictionary": "^3.0.2-browser.5",
+        "browser-style-dictionary": "^3.0.2-browser.6",
         "buffer": "^6.0.3",
         "glob": "^7.2.0",
         "lit": "^2.0.0",
@@ -37,7 +37,7 @@
         "file-loader": "^6.2.0",
         "patch-package": "^6.4.7",
         "rimraf": "^3.0.2",
-        "rollup": "^2.57.0",
+        "rollup": "^2.60.1",
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-visualizer": "^5.5.2",
         "style-loader": "^3.3.0",
@@ -1114,9 +1114,9 @@
       }
     },
     "node_modules/browser-style-dictionary": {
-      "version": "3.0.2-browser.5",
-      "resolved": "https://registry.npmjs.org/browser-style-dictionary/-/browser-style-dictionary-3.0.2-browser.5.tgz",
-      "integrity": "sha512-XX497qZ3RVr8N5AtrBjoXC6iU5FQWeMnx3l8OKzyp7tnx7IHjKV5G5XpitaRjDNTmT9+Pk9ID6+JVRhUATFPUQ==",
+      "version": "3.0.2-browser.6",
+      "resolved": "https://registry.npmjs.org/browser-style-dictionary/-/browser-style-dictionary-3.0.2-browser.6.tgz",
+      "integrity": "sha512-Z3/rV61ZvxAQL+ggFHJUbD6GFTWPqBPeAdG1JAyjgPWedrKrm6QHDnImRV2gTCL2ne/hPJjm85ifGRPj12dAYw==",
       "dependencies": {
         "chalk": "^4.0.0",
         "change-case": "^4.1.2",
@@ -4768,9 +4768,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.58.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.3.tgz",
-      "integrity": "sha512-ei27MSw1KhRur4p87Q0/Va2NAYqMXOX++FNEumMBcdreIRLURKy+cE2wcDJKBn0nfmhP2ZGrJkP1XPO+G8FJQw==",
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.1.tgz",
+      "integrity": "sha512-akwfnpjY0rXEDSn1UTVfKXJhPsEBu+imi1gqBA1ZkHGydUnkV/fWCC90P7rDaLEW8KTwBcS1G3N4893Ndz+jwg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -7081,9 +7081,9 @@
       }
     },
     "browser-style-dictionary": {
-      "version": "3.0.2-browser.5",
-      "resolved": "https://registry.npmjs.org/browser-style-dictionary/-/browser-style-dictionary-3.0.2-browser.5.tgz",
-      "integrity": "sha512-XX497qZ3RVr8N5AtrBjoXC6iU5FQWeMnx3l8OKzyp7tnx7IHjKV5G5XpitaRjDNTmT9+Pk9ID6+JVRhUATFPUQ==",
+      "version": "3.0.2-browser.6",
+      "resolved": "https://registry.npmjs.org/browser-style-dictionary/-/browser-style-dictionary-3.0.2-browser.6.tgz",
+      "integrity": "sha512-Z3/rV61ZvxAQL+ggFHJUbD6GFTWPqBPeAdG1JAyjgPWedrKrm6QHDnImRV2gTCL2ne/hPJjm85ifGRPj12dAYw==",
       "requires": {
         "chalk": "^4.0.0",
         "change-case": "^4.1.2",
@@ -9984,9 +9984,9 @@
       }
     },
     "rollup": {
-      "version": "2.58.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.3.tgz",
-      "integrity": "sha512-ei27MSw1KhRur4p87Q0/Va2NAYqMXOX++FNEumMBcdreIRLURKy+cE2wcDJKBn0nfmhP2ZGrJkP1XPO+G8FJQw==",
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.1.tgz",
+      "integrity": "sha512-akwfnpjY0rXEDSn1UTVfKXJhPsEBu+imi1gqBA1ZkHGydUnkV/fWCC90P7rDaLEW8KTwBcS1G3N4893Ndz+jwg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@lion/core": "^0.18.4",
     "@lion/overlays": "^0.26.1",
-    "browser-style-dictionary": "^3.0.2-browser.5",
+    "browser-style-dictionary": "^3.0.2-browser.6",
     "buffer": "^6.0.3",
     "glob": "^7.2.0",
     "lit": "^2.0.0",
@@ -40,7 +40,7 @@
     "file-loader": "^6.2.0",
     "patch-package": "^6.4.7",
     "rimraf": "^3.0.2",
-    "rollup": "^2.57.0",
+    "rollup": "^2.60.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-visualizer": "^5.5.2",
     "style-loader": "^3.3.0",

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -26,8 +26,6 @@ export async function changeLang(lang) {
 }
 
 export async function encodeContents(files) {
-  const configPath = findUsedConfigPath();
-  files = [configPath, ...files];
   const contents = {};
   await Promise.all(
     files.map(async (file) => {

--- a/src/node/run-style-dictionary.js
+++ b/src/node/run-style-dictionary.js
@@ -1,6 +1,8 @@
 import fs from "fs";
 import util from "util";
 import glob from "glob";
+import path from "path";
+import * as rollup from "rollup";
 import StyleDictionary from "browser-style-dictionary/browser.js";
 import mixpanel from "mixpanel-browser";
 import { repopulateFileTree } from "./file-tree-utils.js";
@@ -59,46 +61,96 @@ function exportCSSPropsToCardFrame() {
 }
 
 export async function rerunStyleDictionaryIfSourceChanged(file) {
-  const { source } = styleDictionaryInstance.options;
-  const sourceFiles = new Set();
+  const { platforms } = styleDictionaryInstance.options;
+  let outputFiles = [];
   await Promise.all(
-    source.map(async (src) => {
-      const matches = await asyncGlob(src, { nodir: true, fs });
-      matches.forEach((m) => {
-        sourceFiles.add(`/${m}`);
+    Object.entries(platforms).map(([key, platform]) => {
+      return new Promise(async (resolve) => {
+        const outFiles = await asyncGlob(`${platform.buildPath}**`, {
+          nodir: true,
+          fs,
+        });
+        outputFiles = [...outputFiles, ...outFiles];
+        resolve();
       });
     })
   );
+  const allFiles = await asyncGlob("**/*", { nodir: true, fs });
+  const inputFiles = allFiles.filter((file) => !outputFiles.includes(file));
 
   // Send to analytics that user ran style dictionary, with how many source files (default 3)
   // to get a feeling of how much they are testing out
   mixpanel.track("Run Dictionary", {
-    sourceFiles: sourceFiles.size,
+    sourceFiles: inputFiles.size,
     platforms: styleDictionaryInstance.platforms,
   });
 
-  const isSourceFile = Array.from(sourceFiles).includes(file);
-  const isConfigFile = configPaths.includes(file);
+  const isInputFile = inputFiles.includes(file.replace(/^\//, ""));
 
   // Only run style dictionary if the config our source tokens were changed
-  if (!isSourceFile && !isConfigFile) {
+  if (!isInputFile) {
     return;
   }
 
-  await runStyleDictionary();
-  const encoded = await encodeContents([...Array.from(sourceFiles)]);
+  const encoded = await encodeContents(inputFiles);
   window.location.href = `${window.location.origin}/#project=${encoded}`;
+  await runStyleDictionary();
 }
 
 export function findUsedConfigPath() {
   return configPaths.find((cfgPath) => fs.existsSync(cfgPath));
 }
 
+/**
+ * Somewhat naive bundle step with rollup
+ * This will allow relative import specifiers inside the playground
+ * Might be nice for JS tokens importing/exporting rather than using
+ * the SD {} reference syntax that you can only use inside "value"s
+ *
+ * EXAMPLE:
+ *
+ *  import foo from '../foo/bar.js';
+ *
+ *  export default {
+ *    "color": {
+ *      ...foo,
+ *    }
+ *  }
+ */
+async function bundle(inputPath) {
+  const rollupCfg = await rollup.rollup({
+    input: inputPath,
+    plugins: [
+      {
+        name: "fake-import",
+        resolveId(source, importer) {
+          let resolved;
+          if (source === inputPath) {
+            resolved = inputPath;
+          } else if (importer) {
+            // try to resolve it from our virtual FS
+            resolved = path.resolve(path.dirname(importer), source);
+          }
+          return resolved;
+        },
+        load(id) {
+          if (id) {
+            // try to load it from our virtual FS
+            return fs.readFileSync(id, "utf-8");
+          }
+        },
+      },
+    ],
+  });
+  const bundle = await rollupCfg.generate({ format: "es" });
+  return bundle.output[0].code;
+}
+
 export default async function runStyleDictionary() {
   console.log("Running style-dictionary...");
   document.querySelector("file-tree").animateCue();
   await cleanPlatformOutputDirs();
-  let newStyleDictionary;
+  let cfgObj;
   const configPath = findUsedConfigPath();
 
   // If .js, we need to parse it as actual JS without resorting to eval/Function
@@ -110,11 +162,30 @@ export default async function runStyleDictionary() {
       new Blob([stringJS], { type: "text/javascript" })
     );
     const configMod = await import(url);
-    const configObj = configMod.default;
-    newStyleDictionary = await StyleDictionary.extend(configObj);
+    cfgObj = configMod.default;
   } else {
-    newStyleDictionary = await StyleDictionary.extend(configPath);
+    cfgObj = JSON.parse(fs.readFileSync(configPath, "utf-8"));
   }
+
+  // Custom parser for JS files
+  cfgObj.parsers = [
+    ...(cfgObj.parsers || []),
+    {
+      // matches ts, js, mjs
+      pattern: /\.(j|mj)s$/,
+      parse: async ({ filePath }) => {
+        const stringJS = fs.readFileSync(filePath, "utf-8");
+        const bundled = await bundle(filePath);
+        const url = URL.createObjectURL(
+          new Blob([bundled], { type: "text/javascript" })
+        );
+        const { default: token } = await import(url);
+        return token;
+      },
+    },
+  ];
+
+  const newStyleDictionary = await StyleDictionary.extend(cfgObj);
   await newStyleDictionary.buildAllPlatforms();
   styleDictionaryInstance = newStyleDictionary;
   await repopulateFileTree();


### PR DESCRIPTION
Example

/#project=rVRRb4IwEP4rpHtYYkhxL0u2PW1L3Oveh1kqFC1CS67FaAj/fddWBNSpS3ZRaK/ffe19vaMhiZKZWNJcK0meSRPLIIiJVjUkPCbPwZd1WJdRay51lKhCQTSZRBPa5Dq0YW1MLGge+tiqYCZTUGob3nThiR7OHSEwqS3wA1Rd2cU9KuwxFfBMbP2aTkdLi1oU6SczK7/qphHGRyNUJgquB3lYa/qhhaRcGyGZEUp6qu8NA8EWGEjH59lT4pGZOZw3OqC9DN7abjj3gzbshMhv0SHX13PN/yHVPtP8cqI52zCdgKhMxPXjxUztCx8tCcc1s2Ca4zZYZKKsFJggUyrIQJXBPaURThABCLh/iSGW9s+3DpfyjNWFwWTAV5jj8yqC35RSigRhN0WJcLMRwjqXwHZHTusuxHJlTvyBk6eouRfg7t0ZZj7AtOGYqeSpqMurVE/OLlOlDNZXiR6cHRH1kyFnTICnZ5If0s1mU7Qh3ZhhCZzLKxzTqWUZcXTD/cC9TqojU9IcfYQG1yy7ipTmqHv6iz5/oMaxUFd8qAB1S21fwO2ggzTHjyEKv7uV0AlykdJwMOJPjGxHXUGe0v7aX33voHjnmyaw3YZHcKR209e3d/zFZH8b7Q8=

Put that after the deploy preview link and you should see a working example where you can use JS tokens in conjunction with JSON tokens, and you can even do relative imports to other files. 

Beware that if you import X into Y, that only Y is matched by the tokens glob in the SD config, otherwise you will get duplicate tokens from both X and Y being matched.