### PR TITLE
feat: make config switch bit more intelligent

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -148,10 +148,15 @@
         share!
       </p>
     </div>
-    <button id="jsSwitchBtn" class="js-switch-btn">
-      Switch to JS config instead of JSON
-    </button>
     <div class="playground-container">
+      <div id="jsSwitchContainer" class="switch-btn-container">
+        <button id="jsSwitchBtn" class="js-switch-btn">Switch to JS</button>
+        <button
+          id="jsSwitchClose"
+          aria-label="Hide these buttons"
+          class="codicon codicon-chrome-close"
+        ></button>
+      </div>
       <file-tree></file-tree>
       <div style="height: 100%" id="monaco-container"></div>
     </div>

--- a/src/node/file-tree-utils.js
+++ b/src/node/file-tree-utils.js
@@ -278,7 +278,18 @@ export async function saveCurrentFile() {
   await rerunStyleDictionaryIfSourceChanged(`/${selectedFile}`);
 }
 
+function openOrCloseJSSwitch(file) {
+  const container = document.getElementById("jsSwitchContainer");
+  if (container.hasAttribute("closed-by-user")) {
+    return;
+  }
+  if (configPaths.includes(`/${file}`) && file.endsWith(".json")) {
+    container.style.display = "flex";
+  }
+}
+
 export async function switchToFile(file) {
+  openOrCloseJSSwitch(file);
   const ext = path.extname(file).slice(1);
   const lang = extensionMap[ext] || ext;
   const fileData = await new Promise((resolve) => {

--- a/src/node/run-style-dictionary.js
+++ b/src/node/run-style-dictionary.js
@@ -33,21 +33,22 @@ async function cleanPlatformOutputDirs() {
 
 // If we don't have the CSS props or card tokens
 // there's no use in showing the card component demo
-function displayOrHideCard() {
-  if (
-    !fs.existsSync("build/css/_variables.css") ||
-    !fs.existsSync("tokens/card/card.json")
-  ) {
+function getCSSText(filePath) {
+  if (!fs.existsSync(filePath)) {
     document.querySelector(".card-container").style.display = "none";
-    return;
+    return "";
   }
-  document.querySelector(".card-container").style.display = "block";
+  const cssProps = fs.readFileSync(filePath, "utf-8");
+  if (cssProps.match(/--sd-card-/g)) {
+    document.querySelector(".card-container").style.display = "block";
+  } else {
+    document.querySelector(".card-container").style.display = "none";
+  }
+  return cssProps;
 }
 
 function exportCSSPropsToCardFrame() {
-  displayOrHideCard();
-
-  const cssProps = fs.readFileSync("build/css/_variables.css", "utf-8");
+  const cssProps = getCSSText("build/css/_variables.css");
 
   const cardFrame = document.getElementById("card-frame");
   // if iframe is not fully loaded we can't inject the CSS sheet yet
@@ -174,7 +175,6 @@ export default async function runStyleDictionary() {
       // matches ts, js, mjs
       pattern: /\.(j|mj)s$/,
       parse: async ({ filePath }) => {
-        const stringJS = fs.readFileSync(filePath, "utf-8");
         const bundled = await bundle(filePath);
         const url = URL.createObjectURL(
           new Blob([bundled], { type: "text/javascript" })

--- a/src/style.css
+++ b/src/style.css
@@ -76,21 +76,6 @@ h1 {
   margin: 0.5rem 0;
 }
 
-.js-switch-btn {
-  background-color: #82dbd2;
-  border: none;
-  padding: 0.5rem 0.75rem;
-  text-align: center;
-  border-radius: 4px;
-  margin: 0 auto 1rem auto;
-  display: block;
-}
-
-.js-switch-btn:hover {
-  cursor: pointer;
-  background-color: #5bb8ae;
-}
-
 .playground-container {
   height: 75vh;
   display: flex;
@@ -98,12 +83,39 @@ h1 {
   box-shadow: 0 5px 6px rgb(0 0 0 / 50%);
   max-width: 1200px;
   margin: 0 auto;
+  position: relative;
 }
 
 .overflow-guard,
 .monaco-editor {
   border-top-right-radius: var(--border-radius-editor);
   border-bottom-right-radius: var(--border-radius-editor);
+}
+
+.switch-btn-container {
+  display: none;
+  align-items: center;
+  gap: 1rem;
+  position: absolute;
+  z-index: 1;
+  left: 50%;
+  top: 20px;
+  transform: translateX(-50%);
+}
+
+.switch-btn-container button {
+  background-color: #82dbd2;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+  border-radius: 4px;
+  margin: 0 auto 1rem auto;
+  height: 2rem;
+}
+
+.switch-btn-container button:hover {
+  cursor: pointer;
+  background-color: #5bb8ae;
 }
 
 file-tree {


### PR DESCRIPTION
Okay so from @georges-gomes  feedback, making the switch to JS config button a bit better.

I didn't go with tooltip as you shouldn't put interactive content in those, popout/popover could work but is quite a bit of work, this solution is a bit cheaper.

- Overlays on the editor
- Only show when user is focused on the config
- Allows to hide it in case it's in the way of editor (reopens on full page refresh)
- Hides when you click it and switch to JS

I'm open to changing it to a global button that turns every JSON into JS, maybe even run prettier on it so it looks nice (right now it keeps the redundant double quotes), but I also don't really feel like investing a ton more effort on the playground, it's better if people just go to Backlight for the full design system experience :). The config is just a quick win because I think many people will want to try a custom formatter for which you need JS config.