### PR TITLE
fix: better error handling, fixed file list width

### DIFF
--- a/src/browser/FileTree.js
+++ b/src/browser/FileTree.js
@@ -76,7 +76,7 @@ class FileTree extends LitElement {
 
         .row {
           cursor: pointer;
-          padding-right: 0.75rem;
+          padding-right: 1.25rem;
         }
 
         img {

--- a/src/browser/FileTree.js
+++ b/src/browser/FileTree.js
@@ -29,11 +29,14 @@ class FileTree extends LitElement {
           flex-direction: column;
           align-items: stretch;
           background-color: #171717;
-          max-width: 400px;
           position: relative;
         }
 
         #file-list {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          width: 200px;
           color: white;
           overflow-y: auto;
         }
@@ -41,6 +44,7 @@ class FileTree extends LitElement {
         .file,
         .folder {
           display: inline-block;
+          width: max-content;
         }
 
         .folder {
@@ -54,12 +58,16 @@ class FileTree extends LitElement {
           margin-left: 1em;
         }
 
+        .file > span {
+          white-space: nowrap;
+        }
+
         #file-list > details {
           margin-bottom: 0.5em;
         }
 
         details {
-          padding-left: 1em;
+          padding-left: 0.75em;
         }
 
         summary {
@@ -68,8 +76,7 @@ class FileTree extends LitElement {
 
         .row {
           cursor: pointer;
-
-          padding-right: 1rem;
+          padding-right: 0.75rem;
         }
 
         img {
@@ -167,14 +174,12 @@ class FileTree extends LitElement {
           }
         }
 
-        #file-list {
-          display: flex;
-          flex-direction: column;
-          height: 100%;
+        .input-files {
+          flex-grow: 1;
+          overflow-x: auto;
         }
 
         .output-files {
-          flex-grow: 1;
           display: flex;
           flex-direction: column;
           justify-content: flex-end;

--- a/src/card/card.html
+++ b/src/card/card.html
@@ -7,6 +7,7 @@
     <title>Document</title>
     <link rel="stylesheet" href="card.css" />
     <script src="https://unpkg.com/construct-style-sheets-polyfill"></script>
+    <script src="card.js"></script>
   </head>
   <body>
     <div class="card">
@@ -16,6 +17,5 @@
       <p>This is a component preview using tokens, with live updates!</p>
       <p id="viewport-text"></p>
     </div>
-    <script src="card.js"></script>
   </body>
 </html>

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -1,12 +1,23 @@
+let res;
+const loadComplete = new Promise((resolve) => {
+  res = resolve;
+});
+
+window.addEventListener("load", () => {
+  res();
+});
+
 // Helper so we can pass CSS from style-dictionary output into this iframe
 // since adopted style sheets may not be shared across documents..
-globalThis.insertCSS = (cssText) => {
+globalThis.insertCSS = async (cssText) => {
   const sheet = new CSSStyleSheet();
   sheet.replaceSync(cssText);
+  await loadComplete;
   document.adoptedStyleSheets = [sheet];
 };
 
-function setViewportText() {
+async function setViewportText() {
+  await loadComplete;
   if (window.innerWidth < 600) {
     document.getElementById("viewport-text").innerText = "Viewport: Mobile";
   } else {

--- a/src/node/file-tree-utils.js
+++ b/src/node/file-tree-utils.js
@@ -233,6 +233,7 @@ export async function removeFile(file) {
 }
 
 export async function openAllFolders() {
+  await fileTreeEl.updateComplete;
   Array.from(fileTreeEl.shadowRoot.querySelectorAll("details")).forEach(
     (el) => {
       el.setAttribute("open", "");
@@ -330,9 +331,17 @@ export async function repopulateFileTree() {
   const files = await asyncGlob("**/*", { fs, mark: true });
 
   const outputFolders = new Set();
-  Object.entries(styleDictionaryInstance.platforms).forEach(([key, value]) => {
-    outputFolders.add(value.buildPath.split("/")[0]);
-  });
+  if (styleDictionaryInstance) {
+    Object.entries(styleDictionaryInstance.platforms).forEach(
+      ([key, value]) => {
+        outputFolders.add(value.buildPath.split("/")[0]);
+      }
+    );
+  } else {
+    console.error(
+      "Trying to repopulate file tree without a valid style-dictionary object to check which files are input vs output."
+    );
+  }
   const inputFiles = files.filter((file) => {
     return !Array.from(outputFolders).some((outputFolder) =>
       file.startsWith(`${outputFolder}/`)
@@ -349,6 +358,9 @@ export async function repopulateFileTree() {
 
 let oldTokens = [];
 function mightDispatchTokens() {
+  if (!styleDictionaryInstance) {
+    return;
+  }
   // Naive compare of the tokens
   if (
     JSON.stringify(oldTokens) !== JSON.stringify(styleDictionaryInstance.tokens)

--- a/src/node/file-tree-utils.js
+++ b/src/node/file-tree-utils.js
@@ -294,6 +294,8 @@ function openOrCloseJSSwitch(file) {
   }
   if (configPaths.includes(`/${file}`) && file.endsWith(".json")) {
     container.style.display = "flex";
+  } else {
+    container.style.display = "none";
   }
 }
 

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -66,7 +66,6 @@ function switchClose(ev) {
   window.addEventListener("sd-tokens-request", dispatchTokens);
   await createInputFiles();
   await runStyleDictionary();
-  await repopulateFileTree();
   await openAllFolders();
   await setupFileChangeHandlers();
   window.addEventListener("resize", async () => {


### PR DESCRIPTION
- File list shifting around was a complaint 2 friends of mine had and I figured it's probably better to just make it fixed with a scrollbar when needed. I also tried truncating, but the experience is not as nice imo.
- The error handling enables users to make a mistake and recover more easily because it's not fatal throw, the contents are still encoded (progress is saved regardless of error), and file tree populates properly for the existing files so that users can edit and not get stuck on an empty editor and file list.. 
- Style-dictionary errors weren't very clear that they were coming from style-dictionary so the extra error handle should help users realize it's a style-dictionary error.
- Fixed issue where the card iframe wasn't fully loaded and insertCSS was called before it exists. Made the card script render-blocking meaning we can be sure it's fully loaded when we receive load event.
- Hide JS config switch when user selects a file that is not the config