### PR TITLE
fix: add await render before inserting CSS

### DIFF
--- a/src/node/run-style-dictionary.js
+++ b/src/node/run-style-dictionary.js
@@ -57,7 +57,9 @@ function exportCSSPropsToCardFrame() {
   // if iframe is not fully loaded we can't inject the CSS sheet yet
   if (cardFrame.contentWindow.document.readyState !== "complete") {
     cardFrame.contentWindow.addEventListener("load", () => {
-      cardFrame?.contentWindow.insertCSS(cssProps);
+      cardFrame.contentWindow.requestAnimationFrame(() => {
+        cardFrame?.contentWindow.insertCSS(cssProps);
+      });
     });
     return;
   }


### PR DESCRIPTION
This ensures the script is fully loaded, since a render can only happen after render-blocking scripts in the head have ran